### PR TITLE
Added Main Menu Styling, made scroll able button

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -46,9 +46,9 @@
             </div>
 
             <div class="labs-scroll">
-              <span class="labs-arrow">&darr;</span>
-              scroll down a little more
-              <span class="labs-arrow">&darr;</span>
+              <span class="labs-arrow left">&darr;</span>
+              <a href="#answers" class="homepage scroll-btn">scroll down a little more</a>
+              <span class="labs-arrow right">&darr;</span>
             </div>
           </div>
         </div>

--- a/layouts/partials/menus/main-menu.html
+++ b/layouts/partials/menus/main-menu.html
@@ -15,7 +15,7 @@
 
 <div class="navbar-item has-dropdown is-hoverable">
   <a href="/events" class="navbar-item">Be Social</a>
-  <div class="navbar-dropdown is-right labs-mobile-dropdown">
+  <div class="navbar-dropdown is-left labs-mobile-dropdown">
     {{ range .Site.Menus.social.ByWeight }}
       <a {{ printf "href=%q" .URL | safeHTMLAttr }} class="navbar-item">
         <span class="icon is-medium">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -24,14 +24,42 @@ body{
   display: inline-block;
 }
 
+.homepage.scroll-btn {
+  border: 2px solid #FFFFFF;
+  display:inline-block;
+  border-radius: 10px;
+  padding: 15px;
+  color:#FFFFFF;
+  margin-left: 30px;
+  margin-right: 30px;
+}
+.homepage.scroll-btn:hover {
+  border: 2px solid #FFFFFF;
+  background-color: #FFFFFF;
+  color: #000000;
+  border-radius: 10px;
+  padding: 15px;
+}
+
 .labs-has-text-white .subtitle, .labs-has-text-white h1, .labs-has-text-white > h2, .labs-has-text-white h3, .labs-has-text-white h4, .labs-has-text-white h5, .labs-has-text-white h6{
   color: #ffffff;
 }
 .labs-nav-logo svg{
   max-height: 5rem;
 }
-.labs-arrow{
-  font-size: 3rem;
+.labs-scroll {
+  position: relative;
+  display: inline-block;
+}
+.labs-arrow {
+  font-size: 2rem;
+  position: absolute;
+}
+.labs-arrow.left {
+  left:0;
+}
+.labs-arrow.right {
+  right:0;
 }
 .labs-border{
   border: 5px dotted #222;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -28,7 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
     let target = document.querySelector('#' + src);
     button.addEventListener("click", (e) => {
       e.preventDefault();
-      target.scrollIntoView({ behavior: 'smooth'});
+      if (target.scrollIntoView) {
+        target.scrollIntoView({ behavior: 'smooth'});
+      }
     })
   });
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -22,4 +22,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  var scrollButtons = document.querySelectorAll(".scroll-btn");
+  scrollButtons.forEach((button) => {
+    let src = button.href.split("/#")[1];
+    let target = document.querySelector('#' + src);
+    button.addEventListener("click", (e) => {
+      e.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth'});
+    })
+  });
+
 });

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -28,8 +28,18 @@ document.addEventListener('DOMContentLoaded', () => {
     let target = document.querySelector('#' + src);
     button.addEventListener("click", (e) => {
       e.preventDefault();
+
       if (target.scrollIntoView) {
-        target.scrollIntoView({ behavior: 'smooth'});
+        target.scrollIntoView(true);
+        // now account for fixed header
+        var scrolledY = window.scrollY;
+
+        if (scrolledY){
+          window.scroll({
+            top:scrolledY - 78,
+            behavior: "smooth"
+          });
+        }
       }
     })
   });


### PR DESCRIPTION
Three things I did.

1. The main menu "social contact" button menu didn't match. It was kind of jarring.
2. Also on the main page is the "scroll down for more". I made that a button that when you clicks automatically scrolls you down. I also made it match the styling a little bit.
3. As part of two I built in a feature that whenever you add an `<a class="scroll-btn" href="#ID_your_scrolling_to">"` it will automatically scroll down smoothly to that id element. This shouldn't have any problems with older browsers...they'll just jump to the section instead of scrolling.