### PR TITLE
Cross out regular hours and add a non-JavaScript COVID-19 notice

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -33,7 +33,8 @@ draft: false
         <div class="column">
           <div class="content">
             <h4 class="title is-4">Regular Hours</h4>
-            <p>Tuesday and Thursdays from 5:00 PM to 10:00 PM</p>
+            <p style="text-decoration:line-through">Tuesday and Thursdays from 5:00 PM to 10:00 PM</p>
+            <p>COVID-19 has forced 801 Labs to temporarily change our physical policy. We will be closed until April 15. <a href="https://www.801labs.org/files/March16-PublicNotice.pdf">Learn more</a></p>
             <h4 class="title is-4">Holiday Hours</h4>
             <p>Ask on our Slack Channel or check our social media for changes</p>
             <b>Other</b>


### PR DESCRIPTION
The current JavaScript-based COVID-19 warning is not prominent enough, disappears after being clicked a single time, and does not appear at all for some users, particularly [NoScript](https://noscript.net/) users.