### PR TITLE
Fix suite number and zip code in hackerspace address

### DIFF
--- a/content/contact.html
+++ b/content/contact.html
@@ -14,7 +14,7 @@ weight: 600
     <section class="section has-text-centered">
       <div class="content">
         <p>board@801labs.org</p>
-        <p>353 East 200 South Suite #B, Salt Lake City, UT 84111</p>
+        <p>353 East 200 South Suite #201, Salt Lake City, UT 84111</p>
         <a href="https://discord.gg/uSQdUPt">
           <span class="icon is-medium">
             <i class="fab fa-discord"></i>

--- a/content/location-and-hours.html
+++ b/content/location-and-hours.html
@@ -15,7 +15,7 @@ weight: 300
       <div class="container">
         <div class="columns">
           <div class="column">
-            <h4 class="title is-4">353 East 200 South Suite #B, Salt Lake City, UT 84111</h4>
+            <h4 class="title is-4">353 East 200 South Suite #201, Salt Lake City, UT 84111</h4>
             <div class="google-maps">
               <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3021.848712761411!2d-111.88284848477637!3d40.76535207932606!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8752f572ad542573%3A0xdd96640329b3d2cb!2s353%20E%20200%20S%20Suite%20%23B%2C%20Salt%20Lake%20City%2C%20UT%2084111!5e0!3m2!1sen!2sus!4v1575941669213!5m2!1sen!2sus" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
             </div>

--- a/content/terms.html
+++ b/content/terms.html
@@ -34,7 +34,7 @@ draft: false
 <h4>Copyright Notice</h4>
 <p>Copyright and other relevant intellectual property rights exists on all text relating to the Company’s services and the full content of this website.</p>
 <h4>Communication</h4>
-<p>We have several different email addresses for different queries. These, and other contact information, can be found throughout the site. This company is registered in Utah at 801 Labs 353 E 200 S Suite 201, Salt Lake City, UT 84103.</p>
+<p>We have several different email addresses for different queries. These, and other contact information, can be found throughout the site. This company is registered in Utah at 801 Labs 353 E 200 S Suite 201, Salt Lake City, UT 84111.</p>
 <h4>Force Majeure</h4>
 <p>Neither party shall be liable to the other for any failure to perform any obligation under any Agreement which is due to an event beyond the control of such party including but not limited to any Act of God, terrorism, war, Skiddies, Political insurgence, insurrection, Effing Hackers, riot, civil unrest, act of civil or military authority, uprising, earthquake, flood or any other natural or man made eventuality outside of our control, which causes the termination of an agreement or contract entered into, nor which could have been reasonably foreseen. Any Party affected by such event shall forthwith inform the other Party of the same and shall use all reasonable endeavours to comply with the terms and conditions of any Agreement contained herein.</p>
 <h4>General</h4>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
       801Labs is a 501(c)(3) charitable non-profit organization!
     </div>
     <address>
-      353 East 200 South Suite #B, Salt Lake City, UT 84111
+      353 East 200 South Suite #201, Salt Lake City, UT 84111
     </address>
     {{- partial "menus/footer-menu.html" . -}}
   </div>


### PR DESCRIPTION
[content/terms.html](https://www.801labs.org/terms/) had the correct suite number, but the wrong zip code. Everywhere else had the right zip code but the wrong suite number.

The address needs to be exactly correct on the website so that I can use the website to convince the USPS and Google Fiber that 801 Labs is a separate entity from the businesses that share the building.

To clear up all doubt, it says on the hall doors that the tattoo parlor is suite 200 and 801 Labs is suite 201:

![IMG_20211026_203204](https://user-images.githubusercontent.com/5951993/139198388-4070f90c-a9c6-49d8-affa-6b23d693f296.jpg)

![IMG_20211026_203159](https://user-images.githubusercontent.com/5951993/139198416-3f7aae7e-fce9-4ca7-a977-7cb11ea8747c.jpg)
